### PR TITLE
Add informative string representation for Sentences models

### DIFF
--- a/tatoeba2/models.py
+++ b/tatoeba2/models.py
@@ -164,6 +164,9 @@ class Sentences(models.Model):
     class Meta:
         db_table = 'sentences'
 
+    def __str__(self):
+        return '<Sentence: id={}>'.format(str(self.id))
+
 class SentencesLists(models.Model):
     id = models.AutoField(primary_key=True)
     is_public = models.IntegerField()


### PR DESCRIPTION
This will show us the id for a sentence whenever we convert it to a string (e.g. when logging it).